### PR TITLE
Fix docker install script path issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,4 @@ docker_users: []
 docker_apt_source_uri: https://apt.dockerproject.org
 docker_yum_source_uri: https://yum.dockerproject.org
 docker_download_dir: '{{ ansible_env.TMPDIR | default("/tmp") }}'
-docker_install_script_path: '{{ docker_download_dir }}/ansible-docker-{{ ansible_user_uid }}-{{ ansible_date_time.epoch }}-{{ (2**48) | random }}'
+docker_install_script_path: '{{ docker_download_dir }}/ansible-docker-{{ ansible_user_uid }}-{{ ansible_date_time.epoch }}'


### PR DESCRIPTION
When run (with Ansible 2.0.1.0) the role failed. Seems the 'random'
part of the path became really random - even between steps in the
same task.

Fixes dochang/ansible-role-docker#4
