### PR TITLE
Use the correct pip executable on Debian

### DIFF
--- a/tasks/docker-py.yml
+++ b/tasks/docker-py.yml
@@ -1,0 +1,17 @@
+---
+- name: include os specific variables
+  include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+        - '{{ ansible_distribution }}.yml'
+        - '{{ ansible_os_family }}.yml'
+        - default.yml
+      paths:
+        - ../vars/installer
+
+- name: install docker-py
+  pip: >-
+    name=docker-py
+    state=present
+    executable={{ pip2_executable }}
+    version={{ docker_dockerpy_version | default(omit) }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,12 +9,7 @@
 - include: install.yml
   when: result | failed
 
-- name: install docker-py
-  pip: >-
-    name=docker-py
-    state=present
-    executable=pip2
-    version={{ docker_dockerpy_version | default(omit) }}
+- include: docker-py.yml
 
 - name: ensure "docker" group present
   group:

--- a/vars/installer/Archlinux.yml
+++ b/vars/installer/Archlinux.yml
@@ -1,3 +1,4 @@
 ---
 docker_installer: pacman
 docker_package: docker
+pip2_executable: pip2

--- a/vars/installer/Debian.yml
+++ b/vars/installer/Debian.yml
@@ -1,4 +1,4 @@
 ---
 docker_installer: default
 docker_package: docker
-pip2_executable: pip2
+pip2_executable: pip


### PR DESCRIPTION
On Debian, `pip`(not `pip2`) is the command to use when installing packages for
Python 2.

Fixes dochang/ansible-role-docker#8
